### PR TITLE
Bump & release github action

### DIFF
--- a/.github/workflows/bump-and-release.yaml
+++ b/.github/workflows/bump-and-release.yaml
@@ -1,0 +1,17 @@
+name: bump & release
+
+on: 
+  push:
+    branches:
+      - main
+
+jobs:
+  release-on-push:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.OSHEPHERD_TOKEN }}
+    steps:
+      - uses: rymndhng/release-on-push-action@master
+        with:
+          bump_version_scheme: patch
+          max_commits: 250


### PR DESCRIPTION
Github Action: https://github.com/rymndhng/release-on-push-action

Creates a Github Release on pushes to main, including release with PR notes and bumping the version.
