### PR TITLE
chat api/worker implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pip install oshepherd
 
 1. Setup RabbitMQ and Redis:
 
-[Celery](https://docs.celeryq.dev) uses [RabbitMQ](https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/index.html#rabbitmq) as message broker, and [Redis](https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/index.html#redis) as backend, you'll need to create one instance for each. You can create small instances for free in [cloudamqp.com](https://www.cloudamqp.com) (for RabbitMQ) and [redislabs.com](https://app.redislabs.com) (for Redids).
+    [Celery](https://docs.celeryq.dev) uses [RabbitMQ](https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/index.html#rabbitmq) as message broker, and [Redis](https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/index.html#redis) as backend, you'll need to create one instance for each. You can create small instances for free in [cloudamqp.com](https://www.cloudamqp.com) and [redislabs.com](https://app.redislabs.com) respectively.
 
 2. Setup Flask API Server:
 
@@ -41,35 +41,35 @@ pip install oshepherd
     oshepherd start-worker --env-file .worker.env
     ```
 
-4. Done, now you're ready to execute Ollama completions remotely, and if you have multiple workers, in a distributed way. You can point your Ollama client to your oshepherd api server by setting the `host`, and it will return your requested completions from any of the workers:
+4. Done, now you're ready to execute Ollama completions remotely. You can point your Ollama client to your oshepherd api server by setting the `host`, and it will return your requested completions from any of the workers:
 
-* [ollama-python](https://github.com/ollama/ollama-python) in Python:
+    * [ollama-python](https://github.com/ollama/ollama-python) client:
 
-```python
-import ollama
-client = ollama.Client(host="http://127.0.0.1:5001")
-ollama_response = client.generate({"model": "mistral", "prompt": "Why is the sky blue?"})
-```
+    ```python
+    import ollama
+    client = ollama.Client(host="http://127.0.0.1:5001")
+    ollama_response = client.generate({"model": "mistral", "prompt": "Why is the sky blue?"})
+    ```
 
-* [ollama-js](https://github.com/ollama/ollama-js) in Javascript:
+    * [ollama-js](https://github.com/ollama/ollama-js) client:
 
-```javascript
-import { Ollama } from "ollama/browser";
-const ollama = new Ollama({ host: "http://127.0.0.1:5001" });
-const ollamaResponse = await ollama.generate({
-    model: "mistral",
-    prompt: "Why is the sky blue?",
-});
-```
+    ```javascript
+    import { Ollama } from "ollama/browser";
+    const ollama = new Ollama({ host: "http://127.0.0.1:5001" });
+    const ollamaResponse = await ollama.generate({
+        model: "mistral",
+        prompt: "Why is the sky blue?",
+    });
+    ```
 
-* Raw http request:
+    * Raw http request:
 
-```sh
-curl -X POST -H "Content-Type: application/json" -L http://127.0.0.1:5001/api/generate/ -d '{
-    "model": "mistral",
-    "prompt":"Why is the sky blue?"
-}'
-```
+    ```sh
+    curl -X POST -H "Content-Type: application/json" -L http://127.0.0.1:5001/api/generate/ -d '{
+        "model": "mistral",
+        "prompt":"Why is the sky blue?"
+    }'
+    ```
 
 ### Words of advice 🚨
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # oshepherd
 
-> The Oshepherd guiding the Ollama(s) inference orchestration.
+> _The Oshepherd guiding the Ollama(s) inference orchestration._
 
-A centralized [Flask](https://flask.palletsprojects.com) API service, using [Celery](https://docs.celeryq.dev) ([RabbitMQ](https://www.rabbitmq.com) + [Redis](https://redis.com)) to orchestrate multiple [Ollama](https://ollama.com) workers.
+A centralized [Flask](https://flask.palletsprojects.com) API service, using [Celery](https://docs.celeryq.dev) ([RabbitMQ](https://www.rabbitmq.com) + [Redis](https://redis.com)) to orchestrate multiple [Ollama](https://ollama.com) servers as workers.
 
 ### Install
 
@@ -14,9 +14,7 @@ pip install oshepherd
 
 1. Setup RabbitMQ and Redis:
 
-    Create instances for free for both:
-        * [cloudamqp.com](https://www.cloudamqp.com)
-        * [redislabs.com](https://app.redislabs.com)
+[Celery](https://docs.celeryq.dev) uses [RabbitMQ](https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/index.html#rabbitmq) as message broker, and [Redis](https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/index.html#redis) as backend, you'll need to create one instance for each. You can create small instances for free in [cloudamqp.com](https://www.cloudamqp.com) (for RabbitMQ) and [redislabs.com](https://app.redislabs.com) (for Redids).
 
 2. Setup Flask API Server:
 
@@ -43,9 +41,39 @@ pip install oshepherd
     oshepherd start-worker --env-file .worker.env
     ```
 
+4. Done, now you're ready to execute Ollama completions remotely, and if you have multiple workers, in a distributed way. You can point your Ollama client to your oshepherd api server by setting the `host`, and it will return your requested completions from any of the workers:
+
+* [ollama-python](https://github.com/ollama/ollama-python) in Python:
+
+```python
+import ollama
+client = ollama.Client(host="http://127.0.0.1:5001")
+ollama_response = client.generate({"model": "mistral", "prompt": "Why is the sky blue?"})
+```
+
+* [ollama-js](https://github.com/ollama/ollama-js) in Javascript:
+
+```javascript
+import { Ollama } from "ollama/browser";
+const ollama = new Ollama({ host: "http://127.0.0.1:5001" });
+const ollamaResponse = await ollama.generate({
+    model: "mistral",
+    prompt: "Why is the sky blue?",
+});
+```
+
+* Raw http request:
+
+```sh
+curl -X POST -H "Content-Type: application/json" -L http://127.0.0.1:5001/api/generate/ -d '{
+    "model": "mistral",
+    "prompt":"Why is the sky blue?"
+}'
+```
+
 ### Words of advice 🚨
 
-This package is in alpha, its architecture and api might change in the near future. Currently this is getting tested in a closed environment by real users, but haven't been audited, nor tested thorugly. Use it at your own risk.
+This package is in alpha, its architecture and api might change in the near future. Currently this is getting tested in a controlled environment by real users, but haven't been audited, nor tested thorugly. Use it at your own risk.
 
 ### Disclaimer on Support
 
@@ -53,7 +81,7 @@ As this is an alpha version, support and responses might be limited. We'll do ou
 
 ### Contribution Guidelines
 
-We welcome contributions! If you find a bug or have suggestions for improvements, please open an issue or submit a pull request.
+We welcome contributions! If you find a bug or have suggestions for improvements, please open an [issue](https://github.com/mnemonica-ai/oshepherd/issues) or submit a [pull request](https://github.com/mnemonica-ai/oshepherd/pulls). Before creating a new issue/pull request, take a moment to search through the existing issues/pull requests to avoid duplicates.
 
 ##### Conda Support
 
@@ -76,13 +104,9 @@ Follow usage instructions to start api server and celery worker using a local ol
 pytest -s tests/
 ```
 
-### Reporting Issues
-
-Please report any issues you encounter on the GitHub issues page. Before creating a new issue, take a moment to search through the existing issues to avoid duplicates.
-
 ### Author
 
-Currently, [mnemonica.ai](mnemonica.ai) is sponsoring the development of this tool.
+This is a project developed and maintained by [mnemonica.ai](mnemonica.ai).
 
 ### License
 

--- a/oshepherd/api/app.py
+++ b/oshepherd/api/app.py
@@ -1,6 +1,7 @@
 from flask import Flask, Blueprint
 from oshepherd.api.config import ApiConfig
 from oshepherd.api.generate.routes import generate_blueprint
+from oshepherd.api.chat.routes import chat_blueprint
 from oshepherd.worker.app import create_celery_app_for_flask
 
 
@@ -19,6 +20,7 @@ def start_flask_app(config: ApiConfig):
     # endpoints
     api = Blueprint("api", __name__)
     api.register_blueprint(generate_blueprint)
+    api.register_blueprint(chat_blueprint)
     app.register_blueprint(api)
 
     app.run(

--- a/oshepherd/api/chat/models.py
+++ b/oshepherd/api/chat/models.py
@@ -1,0 +1,25 @@
+from pydantic import BaseModel, HttpUrl
+from typing import List, Optional
+
+
+class Message(BaseModel):
+    role: str
+    content: str
+    images: Optional[List[HttpUrl]] = None
+
+
+class ChatRequestPayload(BaseModel):
+    model: str  # Required model name
+    messages: Optional[List[Message]] = None
+    format: Optional[str] = "json"
+    options: Optional[dict] = None
+    stream: Optional[bool] = None
+    keep_alive: Optional[str] = "5m"
+
+
+class ChatRequest(BaseModel):
+    type: str
+    payload: ChatRequestPayload
+
+
+# TODO add response type

--- a/oshepherd/api/chat/models.py
+++ b/oshepherd/api/chat/models.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, HttpUrl
 from typing import List, Optional
+from datetime import datetime
 
 
 class Message(BaseModel):
@@ -11,10 +12,10 @@ class Message(BaseModel):
 class ChatRequestPayload(BaseModel):
     model: str  # Required model name
     messages: Optional[List[Message]] = None
-    format: Optional[str] = "json"
-    options: Optional[dict] = None
-    stream: Optional[bool] = None
-    keep_alive: Optional[str] = "5m"
+    format: Optional[str] = ""
+    options: Optional[dict] = {}
+    stream: Optional[bool] = False
+    keep_alive: Optional[str] = None
 
 
 class ChatRequest(BaseModel):
@@ -22,4 +23,14 @@ class ChatRequest(BaseModel):
     payload: ChatRequestPayload
 
 
-# TODO add response type
+class ChatResponse(BaseModel):
+    model: str
+    created_at: datetime
+    message: Message
+    done: bool
+    total_duration: int
+    load_duration: int
+    prompt_eval_count: Optional[int] = None
+    prompt_eval_duration: int
+    eval_count: int
+    eval_duration: int

--- a/oshepherd/api/chat/models.py
+++ b/oshepherd/api/chat/models.py
@@ -10,7 +10,7 @@ class Message(BaseModel):
 
 
 class ChatRequestPayload(BaseModel):
-    model: str  # Required model name
+    model: str
     messages: Optional[List[Message]] = None
     format: Optional[str] = ""
     options: Optional[dict] = {}
@@ -19,7 +19,7 @@ class ChatRequestPayload(BaseModel):
 
 
 class ChatRequest(BaseModel):
-    type: str
+    type: str = "chat"
     payload: ChatRequestPayload
 
 

--- a/oshepherd/api/chat/models.py
+++ b/oshepherd/api/chat/models.py
@@ -1,17 +1,19 @@
-from pydantic import BaseModel, HttpUrl
-from typing import List, Optional
+from pydantic import BaseModel
+from typing import Optional, List, Literal
 from datetime import datetime
 
 
-class Message(BaseModel):
-    role: str
+class ChatMessage(BaseModel):
+    role: Literal["user", "assistant", "system"]
     content: str
-    images: Optional[List[HttpUrl]] = None
+
+    # TODO add support for images
+    # images: NotRequired[Sequence[Any]]
 
 
 class ChatRequestPayload(BaseModel):
     model: str
-    messages: Optional[List[Message]] = None
+    messages: Optional[List[ChatMessage]] = None
     format: Optional[str] = ""
     options: Optional[dict] = {}
     stream: Optional[bool] = False
@@ -26,7 +28,7 @@ class ChatRequest(BaseModel):
 class ChatResponse(BaseModel):
     model: str
     created_at: datetime
-    message: Message
+    message: ChatMessage
     done: bool
     total_duration: int
     load_duration: int

--- a/oshepherd/api/chat/routes.py
+++ b/oshepherd/api/chat/routes.py
@@ -11,13 +11,13 @@ def chat():
     from oshepherd.worker.tasks import exec_completion
 
     print(f" # request.json {request.json}")
-    chat_request = ChatRequest(**{"type": "chat", "payload": request.json})
+    chat_request = ChatRequest(**{"payload": request.json})
 
-    # req as json string ready to be sent though broker
+    # req as json string ready to be sent through broker
     chat_request_json_str = chat_request.model_dump_json()
     print(f" # chat request {chat_request_json_str}")
 
-    # queue request to remote ollama api server though
+    # queue request to remote ollama api server
     task = exec_completion.delay(chat_request_json_str)
     while not task.ready():
         print(" > waiting for response...")

--- a/oshepherd/api/chat/routes.py
+++ b/oshepherd/api/chat/routes.py
@@ -3,6 +3,7 @@ Generate a chat completion
 API implementation of `POST /api/chat` endpoint, handling completion orchestration, as replica of the same Ollama server endpoint.
 Ollama endpoint reference: https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-chat-completion
 """
+
 import time
 from flask import Blueprint, request
 from oshepherd.api.utils import streamify_json

--- a/oshepherd/api/chat/routes.py
+++ b/oshepherd/api/chat/routes.py
@@ -1,3 +1,8 @@
+"""
+Generate a chat completion
+API implementation of `POST /api/chat` endpoint, handling completion orchestration, as replica of the same Ollama server endpoint.
+Ollama endpoint reference: https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-chat-completion
+"""
 import time
 from flask import Blueprint, request
 from oshepherd.api.utils import streamify_json

--- a/oshepherd/api/chat/routes.py
+++ b/oshepherd/api/chat/routes.py
@@ -1,0 +1,37 @@
+import time
+from flask import Blueprint, request
+from oshepherd.api.utils import streamify_json
+from oshepherd.api.chat.models import ChatRequest
+
+chat_blueprint = Blueprint("chat", __name__, url_prefix="/api/chat")
+
+
+@chat_blueprint.route("/", methods=["POST"])
+def chat():
+    from oshepherd.worker.tasks import exec_completion
+
+    print(f" # request.json {request.json}")
+    chat_request = ChatRequest(**{"type": "chat", "payload": request.json})
+
+    # req as json string ready to be sent though broker
+    chat_request_json_str = chat_request.model_dump_json()
+    print(f" # chat request {chat_request_json_str}")
+
+    # queue request to remote ollama api server though
+    task = exec_completion.delay(chat_request_json_str)
+    while not task.ready():
+        print(" > waiting for response...")
+        time.sleep(1)
+    ollama_res = task.get(timeout=1)
+
+    status = 200
+    if ollama_res.get("error"):
+        ollama_res = {
+            "error": "Internal Server Error",
+            "message": f"error executing completion: {ollama_res['error']['message']}",
+        }
+        status = 500
+
+    print(f" $ ollama response {status}: {ollama_res}")
+
+    return streamify_json(ollama_res, status)

--- a/oshepherd/api/generate/models.py
+++ b/oshepherd/api/generate/models.py
@@ -17,7 +17,7 @@ class GenerateRequestPayload(BaseModel):
 
 
 class GenerateRequest(BaseModel):
-    type: str
+    type: str = "generate"
     payload: GenerateRequestPayload
 
 

--- a/oshepherd/api/generate/models.py
+++ b/oshepherd/api/generate/models.py
@@ -2,7 +2,7 @@ from pydantic import BaseModel
 from typing import Optional, List
 
 
-class GenerateRequest(BaseModel):
+class GenerateRequestPayload(BaseModel):
     model: str
     prompt: str
     images: Optional[List[str]] = None
@@ -14,6 +14,11 @@ class GenerateRequest(BaseModel):
     stream: Optional[bool] = False
     raw: Optional[bool] = False
     keep_alive: Optional[str] = "5m"
+
+
+class GenerateRequest(BaseModel):
+    type: str
+    payload: GenerateRequestPayload
 
 
 class GenerateResponse(BaseModel):

--- a/oshepherd/api/generate/routes.py
+++ b/oshepherd/api/generate/routes.py
@@ -11,13 +11,13 @@ def generate():
     from oshepherd.worker.tasks import exec_completion
 
     print(f" # request.json {request.json}")
-    generate_request = GenerateRequest(**{"type": "generate", "payload": request.json})
+    generate_request = GenerateRequest(**{"payload": request.json})
 
-    # req as json string ready to be sent though broker
+    # req as json string ready to be sent through broker
     generate_request_json_str = generate_request.model_dump_json()
     print(f" # generate request {generate_request_json_str}")
 
-    # queue request to remote ollama api server though
+    # queue request to remote ollama api server
     task = exec_completion.delay(generate_request_json_str)
     while not task.ready():
         print(" > waiting for response...")

--- a/oshepherd/api/generate/routes.py
+++ b/oshepherd/api/generate/routes.py
@@ -3,6 +3,7 @@ Generate a completion
 API implementation of `POST /api/generate` endpoint, handling completion orchestration, as replica of the same Ollama server endpoint.
 Ollama endpoint reference: https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-completion
 """
+
 import time
 from flask import Blueprint, request
 from oshepherd.api.utils import streamify_json

--- a/oshepherd/api/generate/routes.py
+++ b/oshepherd/api/generate/routes.py
@@ -1,3 +1,8 @@
+"""
+Generate a completion
+API implementation of `POST /api/generate` endpoint, handling completion orchestration, as replica of the same Ollama server endpoint.
+Ollama endpoint reference: https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-completion
+"""
 import time
 from flask import Blueprint, request
 from oshepherd.api.utils import streamify_json

--- a/oshepherd/cli.py
+++ b/oshepherd/cli.py
@@ -40,7 +40,7 @@ def start_worker(env_file):
         concurrency=config.CONCURRENCY,
         prefetch_multiplier=config.PREFETCH_MULTIPLIER,
         redis_retry_on_timeout=config.REDIS_RETRY_ON_TIMEOUT,
-        redis_socket_keepalive=config.REDIS_SOCKET_KEEPALIVE
+        redis_socket_keepalive=config.REDIS_SOCKET_KEEPALIVE,
     )
     worker.start()
 

--- a/oshepherd/cli.py
+++ b/oshepherd/cli.py
@@ -39,6 +39,8 @@ def start_worker(env_file):
         loglevel=config.LOGLEVEL,
         concurrency=config.CONCURRENCY,
         prefetch_multiplier=config.PREFETCH_MULTIPLIER,
+        redis_retry_on_timeout=config.REDIS_RETRY_ON_TIMEOUT,
+        redis_socket_keepalive=config.REDIS_SOCKET_KEEPALIVE
     )
     worker.start()
 

--- a/oshepherd/worker/config.py
+++ b/oshepherd/worker/config.py
@@ -15,3 +15,5 @@ class WorkerConfig(BaseModel):
         "interval_step": 0.1,
         "interval_max": 0.5,
     }
+    REDIS_RETRY_ON_TIMEOUT: bool = True
+    REDIS_SOCKET_KEEPALIVE: bool = True

--- a/tests/test_e2e_api.py
+++ b/tests/test_e2e_api.py
@@ -1,5 +1,6 @@
 """
-Basic end to end tests, using an equivalent request as pointing to ollama api server in local:
+Basic end to end tests, using Ollama python package, and its equivalent http requests to an Ollama server in local.
+i.e.:
     curl -X POST -H "Content-Type: application/json" -L http://127.0.0.1:11434/api/generate/ -d '{
         "model": "mistral",
         "prompt":"Why is the sky blue?"
@@ -10,9 +11,10 @@ import json
 import requests
 import ollama
 from oshepherd.api.generate.models import GenerateResponse
+from oshepherd.api.chat.models import ChatResponse
 
 
-def test_basic_api_worker_queueing_using_ollama():
+def test_basic_generate_completion_using_ollama():
     params = {"model": "mistral", "prompt": "Why is the sky blue?"}
     client = ollama.Client(host="http://127.0.0.1:5001")
     ollama_res = client.generate(**params)
@@ -21,7 +23,7 @@ def test_basic_api_worker_queueing_using_ollama():
     assert ollama_res.response, "response should not be empty"
 
 
-def test_basic_api_worker_queueing_using_requests():
+def test_basic_generate_completion_using_requests():
     url = "http://127.0.0.1:5001/api/generate/"
     headers = {"Content-Type": "application/json"}
     data = {"model": "mistral", "prompt": "Why is the sky blue?"}
@@ -31,3 +33,30 @@ def test_basic_api_worker_queueing_using_requests():
     assert "error" not in response
     ollama_res = GenerateResponse(**response.json())
     assert ollama_res.response, "response should not be empty"
+
+
+def test_basic_chat_completion_using_ollama():
+    params = {
+        "model": "mistral",
+        "messages": [{"role": "user", "content": "why is the sky blue?"}],
+    }
+    client = ollama.Client(host="http://127.0.0.1:5001")
+    ollama_res = client.chat(**params)
+
+    ollama_res = ChatResponse(**ollama_res)
+    assert ollama_res.message.content, "response should not be empty"
+
+
+def test_basic_chat_completion_using_requests():
+    url = "http://127.0.0.1:5001/api/chat/"
+    headers = {"Content-Type": "application/json"}
+    data = {
+        "model": "mistral",
+        "messages": [{"role": "user", "content": "why is the sky blue?"}],
+    }
+    response = requests.post(url, headers=headers, data=json.dumps(data))
+
+    assert response.status_code == 200
+    assert "error" not in response
+    ollama_res = ChatResponse(**response.json())
+    assert ollama_res.message.content, "response should not be empty"


### PR DESCRIPTION
* `POST /api/chat` endpoint implementation as a flask blueprint ( Ollama docs: https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-chat-completion ).
* Generate and Chat tasks resolution abstracted into only one celery queue for workers.
* Chat request/response types added.
* Default values for Redis backend retry heuristic changed.
* Basic tests added.
