### PR TITLE
embeddings api/worker implementation

### DIFF
--- a/oshepherd/api/app.py
+++ b/oshepherd/api/app.py
@@ -2,6 +2,7 @@ from flask import Flask, Blueprint
 from oshepherd.api.config import ApiConfig
 from oshepherd.api.generate.routes import generate_blueprint
 from oshepherd.api.chat.routes import chat_blueprint
+from oshepherd.api.embeddings.routes import embeddings_blueprint
 from oshepherd.worker.app import create_celery_app_for_flask
 
 
@@ -21,6 +22,7 @@ def start_flask_app(config: ApiConfig):
     api = Blueprint("api", __name__)
     api.register_blueprint(generate_blueprint)
     api.register_blueprint(chat_blueprint)
+    api.register_blueprint(embeddings_blueprint)
     app.register_blueprint(api)
 
     app.run(

--- a/oshepherd/api/chat/models.py
+++ b/oshepherd/api/chat/models.py
@@ -6,7 +6,6 @@ from datetime import datetime
 class ChatMessage(BaseModel):
     role: Literal["user", "assistant", "system"]
     content: str
-
     # TODO add support for images
     # images: NotRequired[Sequence[Any]]
 

--- a/oshepherd/api/embeddings/models.py
+++ b/oshepherd/api/embeddings/models.py
@@ -1,0 +1,18 @@
+from typing import List, Dict, Optional
+from pydantic import BaseModel
+
+
+class EmbeddingsPayload(BaseModel):
+    model: str
+    prompt: str
+    options: Optional[dict] = None
+    keep_alive: Optional[str] = "5m"
+
+
+class EmbeddingsRequest(BaseModel):
+    type: str = "embeddings"
+    payload: EmbeddingsPayload
+
+
+class EmbeddingsResponse(BaseModel):
+    embedding: List[float]

--- a/oshepherd/api/embeddings/routes.py
+++ b/oshepherd/api/embeddings/routes.py
@@ -1,0 +1,43 @@
+"""
+Generate embeddings
+API implementation of `POST /api/embeddings` endpoint, handling embeddings orchestration, as replica of the same Ollama server endpoint.
+Ollama endpoint reference: https://github.com/ollama/ollama/blob/main/docs/api.md#generate-embeddings
+"""
+
+import time
+from flask import Blueprint, request
+from oshepherd.api.utils import streamify_json
+from oshepherd.api.embeddings.models import EmbeddingsRequest
+
+embeddings_blueprint = Blueprint("embeddings", __name__, url_prefix="/api/embeddings")
+
+
+@embeddings_blueprint.route("/", methods=["POST"])
+def embeddings():
+    from oshepherd.worker.tasks import exec_completion
+
+    print(f" # request.json {request.json}")
+    embeddings_request = EmbeddingsRequest(**{"payload": request.json})
+
+    # req as json string ready to be sent through broker
+    embeddings_request_json_str = embeddings_request.model_dump_json()
+    print(f" # embeddings request {embeddings_request_json_str}")
+
+    # queue request to remote ollama api server
+    task = exec_completion.delay(embeddings_request_json_str)
+    while not task.ready():
+        print(" > waiting for response...")
+        time.sleep(1)
+    ollama_res = task.get(timeout=1)
+
+    status = 200
+    if ollama_res.get("error"):
+        ollama_res = {
+            "error": "Internal Server Error",
+            "message": f"error executing completion: {ollama_res['error']['message']}",
+        }
+        status = 500
+
+    print(f" $ ollama response {status}: {ollama_res}")
+
+    return streamify_json(ollama_res, status)

--- a/oshepherd/worker/tasks.py
+++ b/oshepherd/worker/tasks.py
@@ -20,6 +20,8 @@ def exec_completion(self, request_str: str):
             response = ollama.generate(**req_payload)
         elif req_type == "chat":
             response = ollama.chat(**req_payload)
+        elif req_type == "embeddings":
+            response = ollama.embeddings(**req_payload)
 
         print(f"  $ success {response}")
     except Exception as error:

--- a/tests/test_e2e_api.py
+++ b/tests/test_e2e_api.py
@@ -12,6 +12,7 @@ import requests
 import ollama
 from oshepherd.api.generate.models import GenerateResponse
 from oshepherd.api.chat.models import ChatResponse
+from oshepherd.api.embeddings.models import EmbeddingsResponse
 
 
 def test_basic_generate_completion_using_ollama():
@@ -60,3 +61,15 @@ def test_basic_chat_completion_using_requests():
     assert "error" not in response
     ollama_res = ChatResponse(**response.json())
     assert ollama_res.message.content, "response should not be empty"
+
+
+def test_basic_embeddings_using_ollama():
+    params = {
+        "model": "mistral",
+        "prompt": "The sky is blue because of rayleigh scattering"
+    }
+    client = ollama.Client(host="http://127.0.0.1:5001")
+    ollama_res = client.embeddings(**params)
+
+    ollama_res = EmbeddingsResponse(**ollama_res)
+    assert len(ollama_res.embedding) > 0, "response should not be empty"

--- a/tests/test_e2e_api.py
+++ b/tests/test_e2e_api.py
@@ -63,10 +63,25 @@ def test_basic_chat_completion_using_requests():
     assert ollama_res.message.content, "response should not be empty"
 
 
+def test_basic_embeddings_using_requests():
+    url = "http://127.0.0.1:5001/api/embeddings/"
+    headers = {"Content-Type": "application/json"}
+    data = {
+        "model": "mistral",
+        "prompt": "The sky is blue because of rayleigh scattering",
+    }
+    response = requests.post(url, headers=headers, data=json.dumps(data))
+
+    assert response.status_code == 200
+    assert "error" not in response
+    ollama_res = EmbeddingsResponse(**response.json())
+    assert len(ollama_res.embedding) > 0, "response should not be empty"
+
+
 def test_basic_embeddings_using_ollama():
     params = {
         "model": "mistral",
-        "prompt": "The sky is blue because of rayleigh scattering"
+        "prompt": "The sky is blue because of rayleigh scattering",
     }
     client = ollama.Client(host="http://127.0.0.1:5001")
     ollama_res = client.embeddings(**params)


### PR DESCRIPTION
* `POST /api/embeddings` endpoint implementation as a flask blueprint ( Ollama docs: https://github.com/ollama/ollama/blob/main/docs/api.md#generate-embeddings ).
* Embeddings request/response types added.
* Basic tests added.
