### PR TITLE
As default use only Redis as broker and backend

### DIFF
--- a/.api.env.template
+++ b/.api.env.template
@@ -1,2 +1,2 @@
-RABBITMQ_URL="amqps://***"
-REDIS_URL="redis://***"
+CELERY_BROKER_URL="amqps://***"
+CELERY_BACKEND_URL="redis://***"

--- a/.api.env.template
+++ b/.api.env.template
@@ -1,2 +1,2 @@
-CELERY_BROKER_URL="amqps://***"
+CELERY_BROKER_URL="redis://***"
 CELERY_BACKEND_URL="redis://***"

--- a/.worker.env.template
+++ b/.worker.env.template
@@ -1,2 +1,2 @@
-RABBITMQ_URL="amqps://***"
-REDIS_URL="redis://***"
+CELERY_BROKER_URL="amqps://***"
+CELERY_BACKEND_URL="redis://***"

--- a/.worker.env.template
+++ b/.worker.env.template
@@ -1,2 +1,2 @@
-CELERY_BROKER_URL="amqps://***"
+CELERY_BROKER_URL="redis://***"
 CELERY_BACKEND_URL="redis://***"

--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ pip install oshepherd
 
 | Ollama | Oshepherd | Status |
 |-----------------|----------------|----------|
-| `POST /api/generate`| `POST /api/generate`| - [x] Complete |
-| `POST /api/chat`| `POST /api/chat`| - [x] Complete |
-| `POST /api/embeddings`| `POST /api/embeddings`| - [x] Complete |
-| `GET /api/tags`| `GET /api/tags`| - [] Pending |
+| `POST /api/generate`| `POST /api/generate`| [x] Complete |
+| `POST /api/chat`| `POST /api/chat`| [x] Complete |
+| `POST /api/embeddings`| `POST /api/embeddings`| [x] Complete |
+| `GET /api/tags`| `GET /api/tags`| [ ] Pending |
 
 Oshepherd API server has been designed to maintain compatibility with the endpoints defined by Ollama, ensuring that any official client (i.e.: [ollama-python](https://github.com/ollama/ollama-python), [ollama-js](https://github.com/ollama/ollama-js)) can use this server as host and receive expected responses. For more details on the full API specifications, refer to the official [Ollama API documentation](https://github.com/ollama/ollama/blob/main/docs/api.md#api).
 

--- a/README.md
+++ b/README.md
@@ -82,24 +82,10 @@ pip install oshepherd
 
 ### API server parity
 
-| Ollama | Oshepherd | Status |
-|-----------------|----------------|----------|
-| `POST /api/generate`| `POST /api/generate`| [x] Complete |
-| `POST /api/chat`| `POST /api/chat`| [x] Complete |
-| `POST /api/embeddings`| `POST /api/embeddings`| [x] Complete |
-| `GET /api/tags`| `GET /api/tags`| [ ] Pending |
-
-- **Generate a completion:** `POST /api/generate`
-  - **Status:** [x] Complete
-
-- **Generate a chat completion:** `POST /api/chat`
-  - **Status:** [x] Complete
-
-- **Generate Embeddings:** `POST /api/embeddings`
-  - **Status:** [x] Complete
-
-- **List Local Models:** `GET /api/tags`
-  - **Status:** [ ] Pending
+- [x] **Generate a completion:** `POST /api/generate`
+- [x] **Generate a chat completion:** `POST /api/chat`
+- [x] **Generate Embeddings:** `POST /api/embeddings`
+- [ ] **List Local Models:** `GET /api/tags` (pending)
 
 Oshepherd API server has been designed to maintain compatibility with the endpoints defined by Ollama, ensuring that any official client (i.e.: [ollama-python](https://github.com/ollama/ollama-python), [ollama-js](https://github.com/ollama/ollama-js)) can use this server as host and receive expected responses. For more details on the full API specifications, refer to the official [Ollama API documentation](https://github.com/ollama/ollama/blob/main/docs/api.md#api).
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > _The Oshepherd guiding the Ollama(s) inference orchestration._
 
-A centralized [Flask](https://flask.palletsprojects.com) API service, using [Celery](https://docs.celeryq.dev), [RabbitMQ](https://www.rabbitmq.com), and [Redis](https://redis.com) to orchestrate multiple [Ollama](https://ollama.com) servers as workers.
+A centralized [Flask](https://flask.palletsprojects.com) API service, using [Celery](https://docs.celeryq.dev) and [Redis](https://redis.com) to orchestrate multiple [Ollama](https://ollama.com) servers as workers.
 
 ### Install
 
@@ -12,15 +12,15 @@ pip install oshepherd
 
 ### Usage
 
-1. Setup RabbitMQ and Redis:
+1. Setup Redis:
 
-    [Celery](https://docs.celeryq.dev) uses [RabbitMQ](https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/index.html#rabbitmq) as message broker, and [Redis](https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/index.html#redis) as backend. You'll need to create one instance for each. You can create small instances for free in [cloudamqp.com](https://www.cloudamqp.com), and [redislabs.com](https://app.redislabs.com) respectively.
+    [Celery](https://docs.celeryq.dev) uses [Redis](https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/index.html#redis) as message broker and backend. You'll need a Redis instance, which you can provision for free in [redislabs.com](https://app.redislabs.com).
 
 2. Setup Flask API Server:
 
     ```sh
     # define configuration env file
-    # use credentials for redis and rabbitmq
+    # use credentials for redis as broker and backend
     cp .api.env.template .api.env
 
     # start api
@@ -35,7 +35,7 @@ pip install oshepherd
     ollama run mistral
 
     # define configuration env file
-    # use credentials for redis and rabbitmq
+    # use credentials for redis as broker and backend
     cp .worker.env.template .worker.env
 
     # start worker
@@ -82,7 +82,7 @@ pip install oshepherd
 
 ### Contribution guidelines
 
-We welcome contributions! If you find a bug or have suggestions for improvements, please open an [issue](https://github.com/mnemonica-ai/oshepherd/issues) or submit a [pull request](https://github.com/mnemonica-ai/oshepherd/pulls). Before creating a new issue/pull request, take a moment to search through the existing issues/pull requests to avoid duplicates.
+We welcome contributions! If you find a bug or have suggestions for improvements, please open an [issue](https://github.com/mnemonica-ai/oshepherd/issues) or submit a [pull request](https://github.com/mnemonica-ai/oshepherd/pulls) pointing to `development` branch. Before creating a new issue/pull request, take a moment to search through the existing issues/pull requests to avoid duplicates.
 
 ##### Conda Support
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pip install oshepherd
     ```sh
     # install ollama https://ollama.com/download
     # optionally pull the model
-    ollama run mistral
+    ollama pull mistral
 
     # define configuration env file
     # use credentials for redis as broker and backend
@@ -79,6 +79,17 @@ pip install oshepherd
 > This package is in alpha, its architecture and api might change in the near future. Currently this is getting tested in a controlled environment by real users, but haven't been audited, nor tested thorugly. Use it at your own risk.
 >
 > As this is an alpha version, **support and responses might be limited**. We'll do our best to address questions and issues as quickly as possible.
+
+### API server parity
+
+| Ollama | Oshepherd | Status |
+|-----------------|----------------|----------|
+| `POST /api/generate`| `POST /api/generate`| - [x] Complete |
+| `POST /api/chat`| `POST /api/chat`| - [x] Complete |
+| `POST /api/embeddings`| `POST /api/embeddings`| - [x] Complete |
+| `GET /api/tags`| `GET /api/tags`| - [] Pending |
+
+Oshepherd API server has been designed to maintain compatibility with the endpoints defined by Ollama, ensuring that any official client (i.e.: [ollama-python](https://github.com/ollama/ollama-python), [ollama-js](https://github.com/ollama/ollama-js)) can use this server as host and receive expected responses. For more details on the full API specifications, refer to the official [Ollama API documentation](https://github.com/ollama/ollama/blob/main/docs/api.md#api).
 
 ### Contribution guidelines
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 > _The Oshepherd guiding the Ollama(s) inference orchestration._
 
-A centralized [Flask](https://flask.palletsprojects.com) API service, using [Celery](https://docs.celeryq.dev) ([RabbitMQ](https://www.rabbitmq.com) + [Redis](https://redis.com)) to orchestrate multiple [Ollama](https://ollama.com) servers as workers.
+A centralized [Flask](https://flask.palletsprojects.com) API service, using [Celery](https://docs.celeryq.dev), [RabbitMQ](https://www.rabbitmq.com), and [Redis](https://redis.com) to orchestrate multiple [Ollama](https://ollama.com) servers as workers.
 
 ### Install
 
-```
+```sh
 pip install oshepherd
 ```
 
@@ -14,13 +14,13 @@ pip install oshepherd
 
 1. Setup RabbitMQ and Redis:
 
-    [Celery](https://docs.celeryq.dev) uses [RabbitMQ](https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/index.html#rabbitmq) as message broker, and [Redis](https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/index.html#redis) as backend, you'll need to create one instance for each. You can create small instances for free in [cloudamqp.com](https://www.cloudamqp.com) and [redislabs.com](https://app.redislabs.com) respectively.
+    [Celery](https://docs.celeryq.dev) uses [RabbitMQ](https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/index.html#rabbitmq) as message broker, and [Redis](https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/index.html#redis) as backend. You'll need to create one instance for each. You can create small instances for free in [cloudamqp.com](https://www.cloudamqp.com), and [redislabs.com](https://app.redislabs.com) respectively.
 
 2. Setup Flask API Server:
 
-    ```
+    ```sh
     # define configuration env file
-    #   use credentials for redis and rabbitmq
+    # use credentials for redis and rabbitmq
     cp .api.env.template .api.env
 
     # start api
@@ -29,24 +29,26 @@ pip install oshepherd
 
 3. Setup Celery/Ollama Worker(s):
 
-    ```
+    ```sh
     # install ollama https://ollama.com/download
+    # optionally pull the model
     ollama run mistral
 
     # define configuration env file
-    #   use credentials for redis and rabbitmq
+    # use credentials for redis and rabbitmq
     cp .worker.env.template .worker.env
 
     # start worker
     oshepherd start-worker --env-file .worker.env
     ```
 
-4. Done, now you're ready to execute Ollama completions remotely. You can point your Ollama client to your oshepherd api server by setting the `host`, and it will return your requested completions from any of the workers:
+4. Now you're ready to execute Ollama completions remotely. You can point your Ollama client to your oshepherd api server by setting the `host`, and it will return your requested completions from any of the workers:
 
     * [ollama-python](https://github.com/ollama/ollama-python) client:
 
     ```python
     import ollama
+
     client = ollama.Client(host="http://127.0.0.1:5001")
     ollama_response = client.generate({"model": "mistral", "prompt": "Why is the sky blue?"})
     ```
@@ -55,6 +57,7 @@ pip install oshepherd
 
     ```javascript
     import { Ollama } from "ollama/browser";
+
     const ollama = new Ollama({ host: "http://127.0.0.1:5001" });
     const ollamaResponse = await ollama.generate({
         model: "mistral",
@@ -71,15 +74,13 @@ pip install oshepherd
     }'
     ```
 
-### Words of advice 🚨
+### Disclaimers 🚨
 
-This package is in alpha, its architecture and api might change in the near future. Currently this is getting tested in a controlled environment by real users, but haven't been audited, nor tested thorugly. Use it at your own risk.
+> This package is in alpha, its architecture and api might change in the near future. Currently this is getting tested in a controlled environment by real users, but haven't been audited, nor tested thorugly. Use it at your own risk.
+>
+> As this is an alpha version, **support and responses might be limited**. We'll do our best to address questions and issues as quickly as possible.
 
-### Disclaimer on Support
-
-As this is an alpha version, support and responses might be limited. We'll do our best to address questions and issues as quickly as possible.
-
-### Contribution Guidelines
+### Contribution guidelines
 
 We welcome contributions! If you find a bug or have suggestions for improvements, please open an [issue](https://github.com/mnemonica-ai/oshepherd/issues) or submit a [pull request](https://github.com/mnemonica-ai/oshepherd/pulls). Before creating a new issue/pull request, take a moment to search through the existing issues/pull requests to avoid duplicates.
 
@@ -87,7 +88,7 @@ We welcome contributions! If you find a bug or have suggestions for improvements
 
 To run and build locally you can use [conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html):
 
-```
+```sh
 conda create -n oshepherd python=3.8
 conda activate oshepherd
 pip install -r requirements.txt
@@ -100,7 +101,7 @@ pip install -e .
 
 Follow usage instructions to start api server and celery worker using a local ollama, and then run the tests:
 
-```
+```sh
 pytest -s tests/
 ```
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,18 @@ pip install oshepherd
 | `POST /api/embeddings`| `POST /api/embeddings`| [x] Complete |
 | `GET /api/tags`| `GET /api/tags`| [ ] Pending |
 
+- **Generate a completion:** `POST /api/generate`
+  - **Status:** [x] Complete
+
+- **Generate a chat completion:** `POST /api/chat`
+  - **Status:** [x] Complete
+
+- **Generate Embeddings:** `POST /api/embeddings`
+  - **Status:** [x] Complete
+
+- **List Local Models:** `GET /api/tags`
+  - **Status:** [ ] Pending
+
 Oshepherd API server has been designed to maintain compatibility with the endpoints defined by Ollama, ensuring that any official client (i.e.: [ollama-python](https://github.com/ollama/ollama-python), [ollama-js](https://github.com/ollama/ollama-js)) can use this server as host and receive expected responses. For more details on the full API specifications, refer to the official [Ollama API documentation](https://github.com/ollama/ollama/blob/main/docs/api.md#api).
 
 ### Contribution guidelines

--- a/oshepherd/api/app.py
+++ b/oshepherd/api/app.py
@@ -11,8 +11,8 @@ def start_flask_app(config: ApiConfig):
     app.config["FLASK_RUN_PORT"] = config.FLASK_RUN_PORT
     app.config["FLASK_DEBUG"] = config.FLASK_DEBUG
     app.config["FLASK_HOST"] = config.FLASK_HOST
-    app.config["RABBITMQ_URL"] = config.RABBITMQ_URL
-    app.config["REDIS_URL"] = config.REDIS_URL
+    app.config["CELERY_BROKER_URL"] = config.CELERY_BROKER_URL
+    app.config["CELERY_BACKEND_URL"] = config.CELERY_BACKEND_URL
 
     # celery setup
     celery_app = create_celery_app_for_flask(app)

--- a/oshepherd/api/config.py
+++ b/oshepherd/api/config.py
@@ -8,5 +8,5 @@ class ApiConfig(BaseModel):
     FLASK_DEBUG: Optional[bool] = True
     FLASK_RUN_PORT: Optional[int] = 5001
     FLASK_HOST: Optional[str] = "0.0.0.0"
-    RABBITMQ_URL: str
-    REDIS_URL: str
+    CELERY_BROKER_URL: str
+    CELERY_BACKEND_URL: str

--- a/oshepherd/worker/app.py
+++ b/oshepherd/worker/app.py
@@ -16,7 +16,7 @@ def create_celery_app(config: WorkerConfig):
     global celery_app
 
     celery_app = Celery(
-        TASKS_MODULE, broker=config.RABBITMQ_URL, backend=config.REDIS_URL
+        TASKS_MODULE, broker=config.CELERY_BROKER_URL, backend=config.CELERY_BACKEND_URL
     )
     celery_app.conf.update(
         result_expires=config.RESULTS_EXPIRES,
@@ -29,8 +29,8 @@ def create_celery_app(config: WorkerConfig):
 
 def create_celery_app_for_flask(flask_app):
     config = WorkerConfig(
-        RABBITMQ_URL=flask_app.config["RABBITMQ_URL"],
-        REDIS_URL=flask_app.config["REDIS_URL"],
+        CELERY_BROKER_URL=flask_app.config["CELERY_BROKER_URL"],
+        CELERY_BACKEND_URL=flask_app.config["CELERY_BACKEND_URL"],
         RESULTS_EXPIRES=flask_app.config.get(
             "RESULTS_EXPIRES", WorkerConfig.__fields__["RESULTS_EXPIRES"].default
         ),

--- a/oshepherd/worker/config.py
+++ b/oshepherd/worker/config.py
@@ -3,8 +3,8 @@ from typing import Optional
 
 
 class WorkerConfig(BaseModel):
-    RABBITMQ_URL: str
-    REDIS_URL: str
+    CELERY_BROKER_URL: str
+    CELERY_BACKEND_URL: str
     LOGLEVEL: Optional[str] = "info"
     CONCURRENCY: Optional[int] = 1
     PREFETCH_MULTIPLIER: Optional[int] = 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ ollama==0.1.8
 prompt-toolkit==3.0.43
 pydantic==2.6.4
 pydantic_core==2.16.3
+pytest==8.2.2
 python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
 redis==5.0.3


### PR DESCRIPTION
* Direct references to rabbitmq and redis removed, instead referencing broker and backend as celery's own abstractions.
* This makes it easier/cheaper to maintain instead of having two different servers.
* Readme updated.

